### PR TITLE
include <fcntl.h> for musl

### DIFF
--- a/sbin/cleanerd.c
+++ b/sbin/cleanerd.c
@@ -41,6 +41,10 @@
 #include <sys/types.h>
 #endif	/* HAVE_SYS_TYPES_H */
 
+#if HAVE_FCNTL_H
+#include <fcntl.h>
+#endif	/* HAVE_FCNTL_H */
+
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif	/* HAVE_SYS_STAT_H */


### PR DESCRIPTION
- fixes FTBFS on musl systems