### PR TITLE
lib/sb: validate s_log_block_size in nilfs_sb_is_valid()

### DIFF
--- a/lib/sb.c
+++ b/lib/sb.c
@@ -91,6 +91,8 @@ static int nilfs_sb_is_valid(struct nilfs_super_block *sbp, int check_crc)
 		return 0;
 	if (unlikely(le16_to_cpu(sbp->s_bytes) > NILFS_MAX_SB_SIZE))
 		return 0;
+	if (le32_to_cpu(sbp->s_log_block_size) > 6)
+		return 0;
 	if (!check_crc)
 		return 1;
 


### PR DESCRIPTION
Reject superblocks with `s_log_block_size > 6` (block sizes larger than `NILFS_MAX_BLOCK_SIZE`). Without this check, a crafted NILFS2 image causes undefined behavior via oversized shifts or OOM conditions in nilfs-tune, dumpseg, and other read-path tools.

The valid range is 0-6 (1024 to 65536 byte blocks), matching the constants in `nilfs2_ondisk.h` already enforced in mkfs but not in the superblock validator.

One-line fix in `nilfs_sb_is_valid()`.

Fixes: https://github.com/nilfs-dev/nilfs-utils/issues/26